### PR TITLE
Use father class FilesPipeline.__init__() to do __init__()

### DIFF
--- a/firmware/pipelines.py
+++ b/firmware/pipelines.py
@@ -12,14 +12,6 @@ logger = logging.getLogger(__name__)
 
 class FirmwarePipeline(FilesPipeline):
     def __init__(self, store_uri, download_func=None, settings=None):
-        if not store_uri:
-            raise NotConfigured
-
-        if isinstance(settings, dict) or settings is None:
-            settings = Settings(settings)
-
-        self.store = self._get_store(store_uri)
-
         if settings and "SQL_SERVER" in settings:
             import psycopg2
             self.database = psycopg2.connect(database="firmware", user="firmadyne",

--- a/firmware/pipelines.py
+++ b/firmware/pipelines.py
@@ -28,8 +28,7 @@ class FirmwarePipeline(FilesPipeline):
         else:
             self.database = None
 
-        super(FilesPipeline, self).__init__(download_func=download_func)
-
+        super(FirmwarePipeline, self).__init__(store_uri, download_func,settings)
     @classmethod
     def from_settings(cls, settings):
         store_uri = settings['FILES_STORE']


### PR DESCRIPTION
If you call `super(FilesPipeline, self)` it will returns the grandfather class `MediaPipeline`, rather than the father class `FilesPipeline`. Why don't you call

```
super(FirmwarePipeline, self).__init__(store_uri, download_func, settings)
```

Why don't you let `FilesPipeline.__init__()` to handle the code in line 15 to line 22 of `FirmwarePipeline.__init__()` ? 
We don't need to repeat this snippet of code which already handled by FilesPipeline.
