### PR TITLE
OpenWRT scraper skip root link

### DIFF
--- a/firmware/spiders/openwrt.py
+++ b/firmware/spiders/openwrt.py
@@ -14,8 +14,8 @@ class OpenWRTSpider(Spider):
 
     def parse(self, response):
         for link in response.xpath("//a"):
-            text = link.xpath("text()").extract()[0]
-            href = link.xpath("@href").extract()[0]
+            text = link.xpath("text()").extract_first()
+            href = link.xpath("@href").extract_first()
 
             yield Request(
                 url=urlparse.urljoin(response.url, href),
@@ -25,8 +25,8 @@ class OpenWRTSpider(Spider):
 
     def parse_url(self, response):
         for link in response.xpath("//a"):
-            text = link.xpath("text()").extract()[0]
-            href = link.xpath("@href").extract()[0]
+            text = link.xpath("text()").extract_first()
+            href = link.xpath("@href").extract_first()
 
             if ".." in href:
                 continue

--- a/firmware/spiders/openwrt.py
+++ b/firmware/spiders/openwrt.py
@@ -17,6 +17,10 @@ class OpenWRTSpider(Spider):
             text = link.xpath("text()").extract_first()
             href = link.xpath("@href").extract_first()
 
+            if text is None and href == u"/":
+                # <a href="/"><em>(root)</em></a>
+                continue
+
             yield Request(
                 url=urlparse.urljoin(response.url, href),
                 headers={"Referer": response.url},
@@ -27,6 +31,10 @@ class OpenWRTSpider(Spider):
         for link in response.xpath("//a"):
             text = link.xpath("text()").extract_first()
             href = link.xpath("@href").extract_first()
+
+            if text is None and href == u"/":
+                # <a href="/"><em>(root)</em></a>
+                continue
 
             if ".." in href:
                 continue


### PR DESCRIPTION
The root link returned a `None` type, and this was causing the version regex to fail.  Separately, checking for `package/` failed because it checked for substring in `text`, which was `None`.

Still missing some things because of the filtering done in https://github.com/firmadyne/scraper/blob/5b087059c4db6a9f25d38429080a4cf661625e39/firmware/spiders/openwrt.py#L43 will cause it to miss things like:
* https://downloads.openwrt.org/releases/19.07.3/targets/imx6/generic/openwrt-19.07.3-imx6-ventana-squashfs-nand.ubi
* https://downloads.openwrt.org/releases/19.07.3/targets/omap/generic/openwrt-19.07.3-omap-ti_omap3-beagle-squashfs-sdcard.img.gz
* some bootloader images, kernel images, and some device tree files

Perhaps the filtering was intentional so filter updates were left out of the PR.