### PR TITLE
Fix hashing of url in FirmwarePipeline (fixes #15)

### DIFF
--- a/firmware/pipelines.py
+++ b/firmware/pipelines.py
@@ -35,7 +35,7 @@ class FirmwarePipeline(FilesPipeline):
         extension = os.path.splitext(os.path.basename(
             urllib.parse.urlsplit(request.url).path))[1]
         return "%s/%s%s" % (request.meta["vendor"],
-                            hashlib.sha1(request.url).hexdigest(), extension)
+                            hashlib.sha1(request.url.encode("utf8")).hexdigest(), extension)
 
     # overrides function from FilesPipeline
     def get_media_requests(self, item, info):


### PR DESCRIPTION
In Python3 unicode strings must be encoded before hashed. This is not done in the `file_path` function in `FirmwarePipeline`. For some reason Scrapy fails silently and doesn't download the files.

Example:
```
Python 3.9.1 (tags/v3.9.1:1e5d33e, Dec  7 2020, 17:08:21) [MSC v.1927 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import hashlib
>>> hashlib.sha1("test").hexdigest()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Unicode-objects must be encoded before hashing
```